### PR TITLE
Change to allow interface-backed StopLocation entities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,11 @@
       <artifactId>junit</artifactId>
       <version>4.4</version>
     </dependency>
+	<dependency>
+	    <groupId>io.github.classgraph</groupId>
+	    <artifactId>classgraph</artifactId>
+	    <version>4.8.105</version>
+	</dependency>
   </dependencies>
 
 </project>

--- a/src/main/java/org/onebusaway/collections/beans/DefaultPropertyMethodResolver.java
+++ b/src/main/java/org/onebusaway/collections/beans/DefaultPropertyMethodResolver.java
@@ -16,17 +16,49 @@
 package org.onebusaway.collections.beans;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfo;
+import io.github.classgraph.ScanResult;
 
 public class DefaultPropertyMethodResolver implements PropertyMethodResolver {
+
+  private ClassGraph classScanner = new ClassGraph();
 
   @Override
   public PropertyMethod getPropertyMethod(Class<?> targetType,
       String propertyName) {
-    String methodName = "get" + propertyName.substring(0, 1).toUpperCase()
-        + propertyName.substring(1);
+	String methodName = "get";
+	for(String part : propertyName.split(" |_")) {
+	    methodName += part.substring(0, 1).toUpperCase()
+	            + part.substring(1);
+	}
     Method method = null;
     try {
-      method = targetType.getMethod(methodName);
+    	if(targetType.isInterface()) {
+        	ScanResult scanResult = new ClassGraph()
+        			.acceptPackages("org.onebusaway.gtfs")
+        			.enableClassInfo()
+        			.scan();
+
+        	List<Method> methods = new ArrayList<Method>();
+        	for (ClassInfo ci : scanResult.getClassesImplementing(targetType.getCanonicalName())) {
+        		try {
+            		methods.add(Class.forName(ci.getName()).getMethod(methodName));
+        		} catch(Exception e) {
+        			continue;
+        		}
+        	}	
+        	
+        	if(methods.size() == 1)
+        		method = methods.get(0);
+        	else
+        	    throw new IllegalStateException("Ambiguous implementation set for interface: "
+        	              + targetType + " potentials: " + methods);
+    	} else
+        	method = targetType.getMethod(methodName);
     } catch (Exception ex) {
       throw new IllegalStateException("error introspecting class: "
           + targetType, ex);


### PR DESCRIPTION
The GTFS transformer expects to look at the methods on a Java object/bean and match them to GTFS/CSV column names, but can't when the object is an interface (the result of the latest Flex v2 merge where Stops became StopLocation (interfaces)). 

This patch looks at all objects that implement the interface passed in vs. expecting to be able to see what the underlying implementation of the interface is.

Example exception (now fixed):

`java.lang.RuntimeException: java.lang.IllegalStateException: error introspecting class: interface org.onebusaway.gtfs.model.StopLocation
at org.onebusaway.gtfs_transformer.GtfsTransformer.updateGtfs(GtfsTransformer.java:236)
at org.onebusaway.gtfs_transformer.GtfsTransformer.run(GtfsTransformer.java:164)
at org.onebusaway.gtfs_transformer.GtfsTransformerMain.runApplication(GtfsTransformerMain.java:281)
at org.onebusaway.gtfs_transformer.GtfsTransformerMain.run(GtfsTransformerMain.java:117)
at org.onebusaway.gtfs_transformer.GtfsTransformerMain.main(GtfsTransformerMain.java:96)
Caused by: java.lang.IllegalStateException: error introspecting class: interface org.onebusaway.gtfs.model.StopLocation
at org.onebusaway.collections.beans.DefaultPropertyMethodResolver.getPropertyMethod(DefaultPropertyMethodResolver.java:31)
at org.onebusaway.gtfs_transformer.factory.PropertyMethodResolverImpl.getPropertyMethod(PropertyMethodResolverImpl.java:75)
at org.onebusaway.collections.beans.PropertyPathExpression.initialize(PropertyPathExpression.java:102)
at org.onebusaway.collections.beans.PropertyPathExpression.invokeReturningFullResult(PropertyPathExpression.java:148)
at org.onebusaway.gtfs_transformer.match.PropertyValueEntityMatch.isApplicableToObject(PropertyValueEntityMatch.java:35)
at org.onebusaway.gtfs_transformer.match.EntityMatchCollection.isApplicableToObject(EntityMatchCollection.java:31)
at org.onebusaway.gtfs_transformer.match.TypedEntityMatch.isApplicableToObject(TypedEntityMatch.java:36)
at org.onebusaway.gtfs_transformer.factory.EntitiesTransformStrategy.run(EntitiesTransformStrategy.java:62)
at org.onebusaway.gtfs_transformer.GtfsTransformer.updateGtfs(GtfsTransformer.java:233)
... 4 more
Caused by: java.lang.NoSuchMethodException: org.onebusaway.gtfs.model.StopLocation.getParent_station()
at java.base/java.lang.Class.getMethod(Class.java:2108)
at org.onebusaway.collections.beans.DefaultPropertyMethodResolver.getPropertyMethod(DefaultPropertyMethodResolver.java:29`